### PR TITLE
Add rendering settings for screenA and screenB

### DIFF
--- a/screenA/idr0022-screenA-render.yml
+++ b/screenA/idr0022-screenA-render.yml
@@ -1,0 +1,12 @@
+---
+channels:
+    1:
+        active: true
+        color: '808080'
+        end: 1500.0
+        label: Transmitted Light
+        start: 350.0
+greyscale: true
+t: 1
+version: 2
+z: 1

--- a/screenB/idr0022-screenB-render.yml
+++ b/screenB/idr0022-screenB-render.yml
@@ -1,0 +1,12 @@
+---
+channels:
+    1:
+        active: true
+        color: '808080'
+        end: 2000
+        label: Transmitted Light
+        start: 500.0
+greyscale: true
+t: 1
+version: 2
+z: 1


### PR DESCRIPTION
Applied to two plates of the primary screen

<img width="1552" alt="Screen Shot 2019-07-18 at 15 12 37" src="https://user-images.githubusercontent.com/1355463/61464702-9f8faa00-a96e-11e9-8514-ca57a16c60fe.png">
<img width="1552" alt="Screen Shot 2019-07-18 at 15 12 44" src="https://user-images.githubusercontent.com/1355463/61464776-c1892c80-a96e-11e9-90b5-ada34fcc67a0.png">

and two plates of the validation screen

<img width="1552" alt="Screen Shot 2019-07-18 at 15 12 59" src="https://user-images.githubusercontent.com/1355463/61464711-a1f20400-a96e-11e9-98a3-b5fef547c647.png">
<img width="1552" alt="Screen Shot 2019-07-18 at 15 13 08" src="https://user-images.githubusercontent.com/1355463/61464713-a28a9a80-a96e-11e9-9998-f02dc16a379c.png">



